### PR TITLE
[3.5] Regression Fix - Remove text align as it overwrites the attribute

### DIFF
--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -46,7 +46,6 @@ final class FieldDto
     public function __construct()
     {
         $this->uniqueId = new Ulid();
-        $this->textAlign = TextAlign::LEFT;
         $this->cssClass = '';
         $this->columns = null;
         $this->defaultColumns = '';
@@ -227,7 +226,7 @@ final class FieldDto
         $this->virtual = $isVirtual;
     }
 
-    public function getTextAlign(): string
+    public function getTextAlign(): ?string
     {
         return $this->textAlign;
     }


### PR DESCRIPTION
This change fixes some Custom fields post 3.5 migration, The $textAlign variable overwrote any other attribute which could have been defined in a Custom field and would therefore prevent them from working properly. 

I am not sure why this was introduced, but we surely can handle the same via a css class instead. 

This seems quite critical to me to be able to use the attr to pass on parameters to the fields, I am nonetheless happy with any other way to do it. 